### PR TITLE
Detect sort mode for B/SAM files with GO tags

### DIFF
--- a/R/CopywriteR.R
+++ b/R/CopywriteR.R
@@ -135,7 +135,7 @@ CopywriteR <- function(sample.control, destination.folder, reference.folder,
     tryCatch({
         for (samp in sample.paths) {
             header <- scanBamHeader(samp)
-            chr.sort.mode <- c(chr.sort.mode, list(header[[1]]$text$'@HD'))
+            chr.sort.mode <- c(chr.sort.mode, grep("SO:[a-zA-Z]+",  x=header[[1]]$text$"@HD", value=TRUE))
             current.chr.names <- names(header[[1]]$targets)
             chr.names <- c(chr.names, current.chr.names)
             chr.lengths <- c(chr.lengths, header[[1]]$targets)


### PR DESCRIPTION
Many BAM files (e.g. those sorted with picard) have a header line that looks like the following: 

@HD     VN:1.4  GO:none SO:coordinate

The original code to capture the sort order will not identify that these are coordinate sorted files and will capture "GO:none" instead, stopping the run. Using grep instead allows for the sort order to be captured correctly.
